### PR TITLE
Comment out database reset lines✅

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,9 +17,9 @@ void main() async {
   final dir = await path.getApplicationDocumentsDirectory();
   Hive.init(dir.path);
   await Hive.initFlutter(DatabaseConstants.dbName);
-  await Hive.deleteBoxFromDisk(DatabaseConstants.userBox);
-  await Hive.deleteBoxFromDisk(DatabaseConstants.categoriesBox);
-  await Hive.deleteBoxFromDisk(DatabaseConstants.transactionsBox);
+  // await Hive.deleteBoxFromDisk(DatabaseConstants.userBox);
+  // await Hive.deleteBoxFromDisk(DatabaseConstants.categoriesBox);
+  // await Hive.deleteBoxFromDisk(DatabaseConstants.transactionsBox);
   Hive.registerAdapter(TransactionAdapter());
   Hive.registerAdapter(TransactionTypeAdapter());
   Hive.registerAdapter(CategoryAdapter());


### PR DESCRIPTION
- The initialization script for the application was previously set to delete certain data boxes upon startup.
- This commit comments out the lines responsible for deleting the user, categories, and transactions data boxes from Hive, the local storage solution.