### PR TITLE
Refactor category name validation in CategoriesCubit✅

### DIFF
--- a/lib/features/categories/logic/cubit/categories_cubit.dart
+++ b/lib/features/categories/logic/cubit/categories_cubit.dart
@@ -52,16 +52,16 @@ class CategoriesCubit extends Cubit<CategoriesState> {
 
   bool saveCategory() {
     final String categoryName = categoryNameController.text.trim();
+    if (categoryName.isEmpty) {
+      emit(
+          const CategoriesError('Saving failed, please enter a category name'));
+      return false;
+    }
     final List<String> categoryNameFragments = categoryName.split(' ');
     final String capitalizedCategoryName =
         capitalizeCategoryName(categoryNameFragments);
     final categoriesColors = _categoriesRepo.categoriesColors;
     final int categoryColor = categoriesColors[categoryColorController.text]!;
-    if (capitalizedCategoryName.isEmpty) {
-      emit(
-          const CategoriesError('Saving failed, please enter a category name'));
-      return false;
-    }
     if (isCategoryExists(capitalizedCategoryName)) {
       emit(const CategoriesError('Category already exists'));
       return false;

--- a/lib/features/categories/ui/widgets/categories_error_bloc_listener.dart
+++ b/lib/features/categories/ui/widgets/categories_error_bloc_listener.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:money_manager/core/helpers/extensions.dart';
+import 'package:money_manager/core/theming/text_styles.dart';
 import 'package:money_manager/features/categories/logic/cubit/categories_cubit.dart';
 
 class CategoriesErrorBlocListener extends StatelessWidget {
@@ -14,6 +15,7 @@ class CategoriesErrorBlocListener extends StatelessWidget {
           context.clearSnackBar();
           context.showSnackBar(
             message: state.message,
+            textStyle: TextStyles.f14WhiteSemiBold,
           );
         }
       },


### PR DESCRIPTION
- Move the empty category name check to the beginning of the saveCategory method to prevent unnecessary processing and improve readability.
- Update CategoriesErrorBlocListener to use a custom text style for error messages.