### PR TITLE
Refactor changeAttachmentState method in TransactionCubit✅

### DIFF
--- a/lib/features/transaction/logic/cubit/transaction_cubit.dart
+++ b/lib/features/transaction/logic/cubit/transaction_cubit.dart
@@ -86,12 +86,13 @@ class TransactionCubit extends Cubit<TransactionState> {
 
   void changeAttachmentState() {
     if (state is TransactionEditing) {
-      emit(TransactionEditing(
+      emit(
+        TransactionEditing(
           transaction: (state as TransactionEditing).transaction.copyWith(
-                attachmentPath: attachmentPathController.text.isEmpty
-                    ? null
-                    : attachmentPathController.text,
-              )));
+                attachmentPath: attachmentPathController.text,
+              ),
+        ),
+      );
       return;
     }
     if (attachmentPathController.text.isEmpty) {


### PR DESCRIPTION
- The logic for changing the attachment state within the TransactionCubit has been refactored.
- Previously, the code handled an empty attachment path by setting it to null, which was causing an error when the user removing attachment.
- Now, the attachment path is directly assigned from the controller's text.