### PR TITLE
Fix Fake Attachment & Transactions Order✅

### DIFF
--- a/lib/features/home/ui/home_screen.dart
+++ b/lib/features/home/ui/home_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:money_manager/core/widgets/bank_card_widget.dart';
@@ -14,8 +12,6 @@ class HomeScreen extends StatelessWidget {
     context.read<HomeCubit>().getTransactionsData();
     return BlocBuilder<HomeCubit, HomeState>(
       builder: (context, state) {
-        log('HomeScreen building...');
-        log(state.toString());
         if (state is HomeLoading) {
           return const Center(child: CircularProgressIndicator());
         } else if (state is HomeError) {

--- a/lib/features/home/ui/widgets/transactions_list_widget.dart
+++ b/lib/features/home/ui/widgets/transactions_list_widget.dart
@@ -47,7 +47,8 @@ class TransactionsListWidget extends StatelessWidget {
                 padding: EdgeInsets.only(top: 5.h),
                 itemCount: listLength > 5 ? 5 : listLength,
                 itemBuilder: (context, index) {
-                  final Transaction currentTransaction = transactions[index];
+                  final Transaction currentTransaction =
+                      transactions[transactions.length - index - 1];
                   final String categoryName = currentTransaction.categoryName;
                   final Category currentTransactionCategory =
                       homeCubit.getTransactionCategory(categoryName);

--- a/lib/features/transaction/logic/cubit/transaction_cubit.dart
+++ b/lib/features/transaction/logic/cubit/transaction_cubit.dart
@@ -119,10 +119,10 @@ class TransactionCubit extends Cubit<TransactionState> {
         attachmentPathController.text.isNotEmpty;
   }
 
-  String? get getAttachmentPath {
+  String get getAttachmentPath {
     return attachmentPathController.text.isNotEmpty
         ? attachmentPathController.text
-        : null;
+        : '';
   }
 
   String? get getNote {


### PR DESCRIPTION
- Changed the `getAttachmentPath` method to return an empty string instead of null when there is no attachment path.
- Reversed the transaction list to show the latest transactions first.
- Removed unnecessary debug logs from the `HomeScreen`.