### PR TITLE
Initialize default date for new transactions✅

### DIFF
--- a/lib/features/transaction/logic/cubit/transaction_cubit.dart
+++ b/lib/features/transaction/logic/cubit/transaction_cubit.dart
@@ -20,9 +20,14 @@ class TransactionCubit extends Cubit<TransactionState> {
   final formKey = GlobalKey<FormState>();
   Transaction? transactionToEdit;
 
-  void setupTransactionControllers() {
+  void setupNewTransactionControllers() {
     typeController.text = 'Expense';
     categoryController.text = 'Others';
+    dateController.text = getFormattedStringDate;
+  }
+
+  String get getFormattedStringDate {
+    return DateTime.now().toLocal().toString().split(' ')[0];
   }
 
   void processTransaction(bool isEditing) {

--- a/lib/features/transaction/ui/transaction_screen.dart
+++ b/lib/features/transaction/ui/transaction_screen.dart
@@ -28,7 +28,7 @@ class TransactionScreen extends StatelessWidget {
     } else {
       if (transactionCubit.categoryController.text.isEmpty ||
           transactionCubit.typeController.text.isEmpty) {
-        transactionCubit.setupTransactionControllers();
+        transactionCubit.setupNewTransactionControllers();
       }
     }
 


### PR DESCRIPTION
- Refactored `setupNewTransactionControllers` to setup `DateController` too.
- Changed the method name from `setupTransactionControllers` to `setupNewTransactionControllers` to reflect its specific use for new transactions.