### PR TITLE
Update category amount in database✅

### DIFF
--- a/lib/core/database/database_services.dart
+++ b/lib/core/database/database_services.dart
@@ -122,6 +122,7 @@ class DatabaseServices {
 
   void saveTransactionToDatabase(Transaction newTransaction) {
     _transactionsBox.put(newTransaction.createdAt, newTransaction);
+    updateCategoryAmount(newTransaction.categoryName);
   }
 
   void deleteTransactionFromDatabase(String transactionId) {
@@ -156,6 +157,11 @@ class DatabaseServices {
 
   void saveNewCategoryToDatabase(Category newCategory) {
     _categoriesBox.put(newCategory.name, newCategory);
+  }
+
+  void updateCategoryAmount(String categoryName) {
+    final transactionCategory = getCategoryByName(categoryName);
+    saveNewCategoryToDatabase(transactionCategory);
   }
 
   void deleteCategoryFromDatabase(String categoryName) {


### PR DESCRIPTION
- When a new transaction is saved to the database, the corresponding category amount is now updated to reflect the changes.
- This ensures that category balances are accurate and up-to-date following any new transaction entry.
- The `updateCategoryAmount` method is called within the `saveTransactionToDatabase` method, which retrieves the category by name and then saves the updated category back to the database.