### PR TITLE
Finish Splitting Transactions By Month✅

### DIFF
--- a/lib/core/theming/text_styles.dart
+++ b/lib/core/theming/text_styles.dart
@@ -45,6 +45,12 @@ class TextStyles {
     color: AppColors.primaryColor,
   );
 
+  static TextStyle f20PrimaryDarkBold = const TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeights.bold,
+    color: AppColors.primaryDarkColor,
+  );
+
   static TextStyle f20RedBold = const TextStyle(
     fontSize: 20,
     fontWeight: FontWeights.bold,

--- a/lib/core/widgets/custom_app_bar.dart
+++ b/lib/core/widgets/custom_app_bar.dart
@@ -52,5 +52,5 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
-  Size get preferredSize => const Size(double.infinity, 48);
+  Size get preferredSize => const Size(double.infinity, 60);
 }

--- a/lib/features/all_transactions/logic/cubit/all_transactions_cubit.dart
+++ b/lib/features/all_transactions/logic/cubit/all_transactions_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
 import 'package:money_manager/core/models/transaction.dart';
 import 'package:money_manager/features/all_transactions/data/repos/all_transaction_repo.dart';
 
@@ -9,14 +10,28 @@ class AllTransactionsCubit extends Cubit<AllTransactionsState> {
   AllTransactionsCubit(this._allTransactionsRepo)
       : super(const AllTransactionsInitialState());
 
-  List<Transaction> transactionsList = [];
+  // Controller
+  PageController pageController = PageController();
+
+  // Data
+  List<DateTime> pageDates = [];
+  List<Transaction> allTransactionsList = [];
+  Map<String, List<Transaction>> transactionsByMonthMap = {};
+  int currentFilteredListIndex = 0;
 
   void loadAllTransactions(TransactionType transactionType) {
     emit(const AllTransactionsLoadingState());
-    transactionsList = _getAllTypeTransactionsList(transactionType);
-    emit(AllTransactionsLoadedState(transactionsList));
+    allTransactionsList = _getAllTypeTransactionsList(transactionType);
+    // Split transactions into months
+    splitIntoMonths();
+    // Setup page controller
+    setupPageController();
+    // Setup page dates
+    setupPageDates();
+    emit(AllTransactionsLoadedState(allTransactionsList));
   }
 
+  /// Get all transactions list by [transactionType] if it's [TransactionType.expense] or [TransactionType.income]
   List<Transaction> _getAllTypeTransactionsList(
           TransactionType transactionType) =>
       _allTransactionsRepo.getFilteredTransactions(transactionType);
@@ -44,37 +59,122 @@ class AllTransactionsCubit extends Cubit<AllTransactionsState> {
       case 'By Category':
         categorySorting();
     }
-    emit(AllTransactionsLoadedState(transactionsList));
+    emit(AllTransactionsLoadedState(
+        transactionsByMonthMap.values.elementAt(currentFilteredListIndex)));
+  }
+
+  /// Split the transactions list into months to be able to filter them by month
+  void splitIntoMonths() {
+    // Sort transactions by date to prevent any issues in splitting
+    allTransactionsList.sort((a, b) {
+      return b.date.compareTo(a.date);
+    });
+    final List<Transaction> transactions = allTransactionsList;
+    final List<Transaction> currentMonthTransactions = [];
+    int currentMonth = transactions.first.date.month;
+    int currentYear = transactions.first.date.year;
+    for (final Transaction transaction in transactions) {
+      // Check if the current transaction is in the same month and year
+      if (currentMonth == transaction.date.month &&
+          currentYear == transaction.date.year) {
+        currentMonthTransactions.add(transaction);
+      } else {
+        // Add the current month transactions to the map then clear the list and update the month and year
+        transactionsByMonthMap['$currentMonth-$currentYear'] = [
+          ...currentMonthTransactions
+        ];
+        currentMonthTransactions.clear();
+        currentMonthTransactions.add(transaction);
+        currentMonth = transaction.date.month;
+        currentYear = transaction.date.year;
+      }
+    }
+    transactionsByMonthMap['$currentMonth-$currentYear'] = [
+      ...currentMonthTransactions
+    ];
   }
 
   /// Sorting the transactions list by price with ascending ordering
   void lowestSorting() {
-    transactionsList.sort((a, b) => a.amount.compareTo(b.amount));
+    setupCurrentIndex();
+
+    transactionsByMonthMap.values
+        .elementAt(currentFilteredListIndex)
+        .sort((a, b) => a.amount.compareTo(b.amount));
   }
 
   /// Sorting the transactions list by price with descending ordering
   void highestSorting() {
-    transactionsList.sort((a, b) => b.amount.compareTo(a.amount));
+    setupCurrentIndex();
+
+    transactionsByMonthMap.values
+        .elementAt(currentFilteredListIndex)
+        .sort((a, b) => b.amount.compareTo(a.amount));
   }
 
   /// Sorting the transactions list by date with descending ordering
   void newestSorting() {
-    transactionsList.sort((a, b) => b.date.compareTo(a.date));
+    setupCurrentIndex();
+
+    transactionsByMonthMap.values
+        .elementAt(currentFilteredListIndex)
+        .sort((a, b) => b.date.compareTo(a.date));
   }
 
   /// Sorting the transactions list by date with ascending ordering
   void oldestSorting() {
-    transactionsList.sort((a, b) => a.date.compareTo(b.date));
+    setupCurrentIndex();
+
+    transactionsByMonthMap.values
+        .elementAt(currentFilteredListIndex)
+        .sort((a, b) => a.date.compareTo(b.date));
   }
 
   /// Sorting the transactions list by the highst amount category
   void categorySorting() {
-    transactionsList.sort((a, b) {
+    setupCurrentIndex();
+
+    transactionsByMonthMap.values
+        .elementAt(currentFilteredListIndex)
+        .sort((a, b) {
       final double firstCategoryTotalAmount =
           _allTransactionsRepo.getCategoryByName(a.categoryName).totalAmount;
       final double secondCategoryTotalAmount =
           _allTransactionsRepo.getCategoryByName(b.categoryName).totalAmount;
       return secondCategoryTotalAmount.compareTo(firstCategoryTotalAmount);
     });
+  }
+
+  /// Get the oldest transaction date from the transactions list
+  DateTime getOldestTransactionDate() {
+    allTransactionsList.sort((a, b) => a.date.compareTo(b.date));
+    return allTransactionsList.first.date;
+  }
+
+  /// Get the newest transaction date from the transactions list
+  DateTime getNewestTransactionDate() {
+    allTransactionsList.sort((a, b) => b.date.compareTo(a.date));
+    return allTransactionsList.first.date;
+  }
+
+  // Helper functions
+  void setupPageController() {
+    pageController = PageController(
+      initialPage: transactionsByMonthMap.keys.length - 1,
+    );
+  }
+
+  void setupCurrentIndex() {
+    currentFilteredListIndex =
+        transactionsByMonthMap.keys.length - 1 - pageController.page!.toInt();
+  }
+
+  void setupPageDates() {
+    pageDates = transactionsByMonthMap.keys
+        .toList()
+        .reversed
+        .map((strDate) => DateTime(int.parse(strDate.split('-').last),
+            int.parse(strDate.split('-').first)))
+        .toList();
   }
 }

--- a/lib/features/all_transactions/ui/all_transactions_screen.dart
+++ b/lib/features/all_transactions/ui/all_transactions_screen.dart
@@ -8,8 +8,9 @@ import 'package:money_manager/core/theming/colors.dart';
 import 'package:money_manager/core/theming/text_styles.dart';
 import 'package:money_manager/core/widgets/custom_app_bar.dart';
 import 'package:money_manager/features/all_transactions/logic/cubit/all_transactions_cubit.dart';
-import 'package:money_manager/features/all_transactions/ui/widgets/all_transactions_list_view.dart';
 import 'package:money_manager/features/all_transactions/ui/widgets/empty_transactions.dart';
+
+import 'widgets/transactions_body.dart';
 
 class AllTransactionsScreen extends StatelessWidget {
   final TransactionType transactionType;
@@ -24,7 +25,8 @@ class AllTransactionsScreen extends StatelessWidget {
         ? AppString.expense.tr()
         : AppString.income.tr();
 
-    final bool noTransactions = allTransactionsCubit.transactionsList.isEmpty;
+    final bool noTransactions =
+        allTransactionsCubit.allTransactionsList.isEmpty;
 
     final String languageCode = context.locale.languageCode;
 
@@ -49,7 +51,7 @@ class AllTransactionsScreen extends StatelessWidget {
             ? EmptyTransactions(
                 transactionType: transactionType,
               )
-            : const AllTransactionsListView(),
+            : const TransactionsBody(),
       ),
     );
   }

--- a/lib/features/all_transactions/ui/widgets/all_transactions_list_view.dart
+++ b/lib/features/all_transactions/ui/widgets/all_transactions_list_view.dart
@@ -7,7 +7,10 @@ import 'package:money_manager/features/all_transactions/logic/cubit/all_transact
 class AllTransactionsListView extends StatelessWidget {
   const AllTransactionsListView({
     super.key,
+    required this.transactions,
   });
+
+  final List<Transaction> transactions;
 
   @override
   Widget build(BuildContext context) {
@@ -20,16 +23,14 @@ class AllTransactionsListView extends StatelessWidget {
     return BlocBuilder<AllTransactionsCubit, AllTransactionsState>(
       buildWhen: (previous, current) => current is AllTransactionsLoadedState,
       builder: (context, state) {
-        final List<Transaction> allTypeTransactions =
-            (state as AllTransactionsLoadedState).allTransactions.toList();
         return ListView.builder(
-          itemCount: allTypeTransactions.length,
+          itemCount: transactions.length,
           itemBuilder: (context, index) {
-            final Transaction currentTransaction = allTypeTransactions[index];
+            final Transaction currentTransaction = transactions[index];
             final Category currentTransactionCategory = allTransactionsCubit
                 .getTransactionCategory(currentTransaction.categoryName);
             return TransactionItemCard(
-                transactionData: allTypeTransactions[index],
+                transactionData: transactions[index],
                 transactionCategory: currentTransactionCategory,
                 isPeriodicDate: isPeriodicFormat,
                 currencyAbbreviation: currencyAbbreviation);

--- a/lib/features/all_transactions/ui/widgets/date_header.dart
+++ b/lib/features/all_transactions/ui/widgets/date_header.dart
@@ -1,0 +1,21 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:money_manager/core/theming/text_styles.dart';
+import 'package:money_manager/features/all_transactions/logic/cubit/all_transactions_cubit.dart';
+
+class DateHeader extends StatelessWidget {
+  const DateHeader({super.key, required this.pageIndex});
+
+  final int pageIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<DateTime> allDates =
+        context.read<AllTransactionsCubit>().pageDates;
+    return Text(
+      DateFormat.yMMMM().format(allDates[pageIndex]),
+      style: TextStyles.f20PrimaryDarkBold,
+    );
+  }
+}

--- a/lib/features/all_transactions/ui/widgets/empty_transactions.dart
+++ b/lib/features/all_transactions/ui/widgets/empty_transactions.dart
@@ -1,4 +1,6 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:money_manager/core/helpers/app_string.dart';
 import 'package:money_manager/core/helpers/extensions.dart';
 import 'package:money_manager/core/helpers/spacing.dart';
 import 'package:money_manager/core/models/transaction.dart';
@@ -18,7 +20,7 @@ class EmptyTransactions extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           Text(
-            'There are no ${transactionType}s, \n try to log new $transactionType',
+            AppString.noTransactions.tr(),
             style: TextStyles.f14GreySemiBold.copyWith(
                 fontSize: TextStyles.getResponsiveFontSize(context,
                     baseFontSize: 16)),
@@ -35,7 +37,7 @@ class EmptyTransactions extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10.0),
                 )),
             child: Text(
-              'Add New Transaction',
+              AppString.addNewTransaction.tr(),
               style: TextStyles.f16WhiteMedium,
             ),
           ),

--- a/lib/features/all_transactions/ui/widgets/transactions_body.dart
+++ b/lib/features/all_transactions/ui/widgets/transactions_body.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:money_manager/core/models/transaction.dart';
+import 'package:money_manager/features/all_transactions/logic/cubit/all_transactions_cubit.dart';
+import 'package:money_manager/features/all_transactions/ui/widgets/all_transactions_list_view.dart';
+import 'package:money_manager/features/all_transactions/ui/widgets/date_header.dart';
+
+class TransactionsBody extends StatefulWidget {
+  const TransactionsBody({
+    super.key,
+  });
+
+  @override
+  State<TransactionsBody> createState() => _TransactionsBodyState();
+}
+
+class _TransactionsBodyState extends State<TransactionsBody> {
+  late PageController _pageController;
+  int currentPageIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = context.read<AllTransactionsCubit>().pageController;
+    currentPageIndex = context
+            .read<AllTransactionsCubit>()
+            .transactionsByMonthMap
+            .keys
+            .length -
+        1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AllTransactionsCubit allTransactionsCubit =
+        context.read<AllTransactionsCubit>();
+    final transactionsMap = allTransactionsCubit.transactionsByMonthMap;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 15),
+          child: DateHeader(
+            pageIndex: currentPageIndex,
+          ),
+        ),
+        Expanded(
+          child: PageView.builder(
+            onPageChanged: (index) {
+              setState(() {
+                currentPageIndex = index;
+              });
+            },
+            controller: _pageController,
+            itemCount: transactionsMap.length,
+            itemBuilder: (context, index) {
+              final List<Transaction> transactions =
+                  _getCurrentPageTransactions(transactionsMap, index);
+              return AllTransactionsListView(
+                transactions: transactions,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<Transaction> _getCurrentPageTransactions(
+      Map<String, List<Transaction>> transactionsMap, int index) {
+    final List<Transaction> transactions =
+        transactionsMap.values.toList().reversed.elementAt(index);
+    return transactions;
+  }
+}

--- a/lib/features/home/ui/widgets/transactions_container.dart
+++ b/lib/features/home/ui/widgets/transactions_container.dart
@@ -5,6 +5,7 @@ import 'package:money_manager/core/helpers/app_string.dart';
 import 'package:money_manager/core/helpers/extensions.dart';
 import 'package:money_manager/core/helpers/spacing.dart';
 import 'package:money_manager/core/routing/routes.dart';
+import 'package:money_manager/core/theming/colors.dart';
 import 'package:money_manager/core/theming/text_styles.dart';
 import 'package:money_manager/core/models/transaction.dart';
 import 'package:money_manager/features/home/ui/widgets/transactions_list_widget.dart';

--- a/lib/features/home/ui/widgets/transactions_header_widget.dart
+++ b/lib/features/home/ui/widgets/transactions_header_widget.dart
@@ -30,6 +30,7 @@ class _TransactionsHeaderWidget extends StatelessWidget {
             },
             child: Text(AppString.seeAll.tr(),
                 style: TextStyles.f15GreyRegular.copyWith(
+                    color: AppColors.lightPrimaryColor,
                     fontSize: TextStyles.getResponsiveFontSize(context,
                         baseFontSize: 15))),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
     source: hosted
     version: "2.4.2"
   build_runner:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: build_runner
       sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
@@ -340,7 +340,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_native_splash:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: flutter_native_splash
       sha256: "58fb249fb19ffe979e4ad288de018a118768988b1f497e6ff0b23ead6f5a1bc5"
@@ -382,7 +382,7 @@ packages:
     source: sdk
     version: "0.0.0"
   freezed:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: freezed
       sha256: "57247f692f35f068cae297549a46a9a097100685c6780fe67177503eea5ed4e5"
@@ -390,7 +390,7 @@ packages:
     source: hosted
     version: "2.4.7"
   freezed_annotation:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: freezed_annotation
       sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,6 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  build_runner: ^2.4.7
   cupertino_icons: ^1.0.2
   dotted_border: ^2.1.0
   file_picker: ^8.0.0+1
@@ -36,11 +35,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3
-  flutter_native_splash: ^2.3.9
   flutter_screenutil: ^5.9.0
   flutter_svg: ^2.0.9
-  freezed: ^2.4.6
-  freezed_annotation: ^2.4.1
   get_it: ^7.6.6
   hive: ^2.2.3
   hive_flutter: ^1.1.0
@@ -55,8 +51,12 @@ dev_dependencies:
   flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
+  flutter_native_splash: ^2.3.9
+  build_runner: ^2.4.7
   hive_generator: ^2.0.1
   flutter_launcher_icons: ^0.13.1
+  freezed: ^2.4.6
+  freezed_annotation: ^2.4.1
 flutter_icons:
   image_path: "assets/images/logo.png"
   android: true


### PR DESCRIPTION
- Handled the logic of the splitting transactions in `AllTransactionCubit`.
- Added some widgets `DateHeader` to hold the date info, and the `TransactionBody`.
- Added some missed `tr()` methods to empty transaction screen.
- Refactored `CustomAppBar` to take 60 as height of the screen.