### PR TITLE
Fix Transaction Deletion Logic✅

### DIFF
--- a/lib/features/home/ui/widgets/transactions_list_widget.dart
+++ b/lib/features/home/ui/widgets/transactions_list_widget.dart
@@ -79,6 +79,7 @@ class TransactionsListWidget extends StatelessWidget {
   }
 
   void onDismissed(BuildContext context, Transaction transaction) {
+    ScaffoldMessenger.of(context).removeCurrentSnackBar();
     final BankCardCubit bankCardCubit = context.read<BankCardCubit>();
     bankCardCubit.updateBankCardDataOnDeleteTransaction(transaction);
     showUndoSnackBar(context, transaction);


### PR DESCRIPTION
- Handle on delete transaction to make it firstly remove the current snack bar which will make it remove the deleted transaction from database.